### PR TITLE
fix: read AKS OIDC issuer from live cluster (drift fix)

### DIFF
--- a/tofu/identity.tf
+++ b/tofu/identity.tf
@@ -13,6 +13,16 @@ data "azurerm_resource_group" "infra" {
   name = local.infra.resource_group_name
 }
 
+# Live cluster OIDC issuer URL. Previously pinned via var.cluster_oidc_issuer_url
+# default — that drifted silently when infra-bootstrap rebuilt the AKS cluster
+# and the federated cred kept presenting the old issuer (AADSTS700211). Reading
+# it from the cluster directly keeps the credential in lockstep with the
+# current cluster — matches diagrams/tofu/identity.tf.
+data "azurerm_kubernetes_cluster" "infra" {
+  name                = "infra-aks"
+  resource_group_name = local.infra.resource_group_name
+}
+
 resource "azurerm_user_assigned_identity" "investing" {
   name                = "investing-identity"
   resource_group_name = data.azurerm_resource_group.infra.name
@@ -42,7 +52,7 @@ resource "azurerm_federated_identity_credential" "investing" {
   resource_group_name = local.infra.resource_group_name
   parent_id           = azurerm_user_assigned_identity.investing.id
   audience            = ["api://AzureADTokenExchange"]
-  issuer              = var.cluster_oidc_issuer_url
+  issuer              = data.azurerm_kubernetes_cluster.infra.oidc_issuer_url
   subject             = "system:serviceaccount:investing:infra-shared"
 }
 

--- a/tofu/variables.tf
+++ b/tofu/variables.tf
@@ -3,9 +3,3 @@ variable "location" {
   type        = string
   default     = "westus2"
 }
-
-variable "cluster_oidc_issuer_url" {
-  description = "OIDC issuer URL for the active AKS cluster used for workload identity federation"
-  type        = string
-  default     = "https://westus2.oic.prod-aks.azure.com/2236b5e4-81d2-4d82-bde5-17b1037999ea/dca02d36-5485-474f-acfb-b2d897a982e1/"
-}


### PR DESCRIPTION
## Summary

investing has been in CrashLoopBackOff (503 at investing.romaine.life) since infra-bootstrap rebuilt the AKS cluster. Pods present a SA token signed by the cluster's current OIDC issuer URL (`…/5aced6d5-…/`), but Azure's stored federated credential is pinned to the old one (`…/dca02d36-…/`), so the token exchange returns:

```
AADSTS700211: No matching federated identity record found for presented assertion issuer
```

Root cause: `tofu/identity.tf` set `issuer = var.cluster_oidc_issuer_url`, with the variable's default hardcoded to the old URL in `variables.tf`. Cluster rebuilds invalidate that default silently.

Switch to `data.azurerm_kubernetes_cluster.infra.oidc_issuer_url` (the pattern every healthy app UAMI uses — diagrams, fzt-frontend, llm-explorer, infra-shared, mcp-*). Drop the unused variable.

## Test plan
- [x] Tofu plan shows a single in-place update on `azurerm_federated_identity_credential.investing.issuer`
- [ ] After apply: `az identity federated-credential list --identity-name investing-identity` shows the new issuer URL
- [ ] After ArgoCD restarts the deployment: pod transitions to Ready and `investing.romaine.life` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)