### PR TITLE
fix(tofu): pin federated cred issuer to current cluster URL (cross-sub workaround)

### DIFF
--- a/tofu/identity.tf
+++ b/tofu/identity.tf
@@ -13,16 +13,6 @@ data "azurerm_resource_group" "infra" {
   name = local.infra.resource_group_name
 }
 
-# Live cluster OIDC issuer URL. Previously pinned via var.cluster_oidc_issuer_url
-# default — that drifted silently when infra-bootstrap rebuilt the AKS cluster
-# and the federated cred kept presenting the old issuer (AADSTS700211). Reading
-# it from the cluster directly keeps the credential in lockstep with the
-# current cluster — matches diagrams/tofu/identity.tf.
-data "azurerm_kubernetes_cluster" "infra" {
-  name                = "infra-aks"
-  resource_group_name = local.infra.resource_group_name
-}
-
 resource "azurerm_user_assigned_identity" "investing" {
   name                = "investing-identity"
   resource_group_name = data.azurerm_resource_group.infra.name
@@ -52,7 +42,7 @@ resource "azurerm_federated_identity_credential" "investing" {
   resource_group_name = local.infra.resource_group_name
   parent_id           = azurerm_user_assigned_identity.investing.id
   audience            = ["api://AzureADTokenExchange"]
-  issuer              = data.azurerm_kubernetes_cluster.infra.oidc_issuer_url
+  issuer              = var.cluster_oidc_issuer_url
   subject             = "system:serviceaccount:investing:infra-shared"
 }
 

--- a/tofu/variables.tf
+++ b/tofu/variables.tf
@@ -3,3 +3,15 @@ variable "location" {
   type        = string
   default     = "westus2"
 }
+
+# Pinned to the AKS cluster's current OIDC issuer URL. The cluster lives in
+# a dedicated subscription (606a1ca1, "romaine-life"); this tofu stack runs
+# in another (aee0cbd2, "Azure subscription 1"), so we can't read the live
+# value via `data "azurerm_kubernetes_cluster"` without cross-subscription
+# Reader on the CI principal — which we don't have today. Bump this value
+# whenever infra-bootstrap rebuilds the cluster.
+variable "cluster_oidc_issuer_url" {
+  description = "OIDC issuer URL for the active AKS cluster used for workload identity federation"
+  type        = string
+  default     = "https://westus2.oic.prod-aks.azure.com/2236b5e4-81d2-4d82-bde5-17b1037999ea/5aced6d5-4299-421b-84a9-6638aebbf4f0/"
+}


### PR DESCRIPTION
## Summary

Follow-up to #18, which switched the federated identity credential's `issuer` to `data.azurerm_kubernetes_cluster.infra.oidc_issuer_url`. The data source 404s because the AKS cluster lives in subscription `606a1ca1` (romaine-life) while this tofu stack authenticates to `aee0cbd2` (Azure subscription 1) — same failure mode as diagrams/tofu, which hasn't applied successfully since 2026-04-30.

The cross-sub fix (Reader role for the CI principal on the cluster sub, or a provider alias with explicit subscription_id) is owned by infra-bootstrap. Until that lands, restore the hardcoded variable approach but with the cluster's **current** issuer URL (`…/5aced6d5-…`).

After this merges, tofu apply will plan a single in-place update on the federated cred's `issuer`, the new URL gets stamped on Azure, and the pod can do its workload-identity token exchange.

## Test plan
- [x] Tofu plan shows in-place update on `azurerm_federated_identity_credential.investing.issuer`
- [ ] After apply: `az identity federated-credential list --identity-name investing-identity` shows the new issuer URL
- [ ] After deployment restart: `investing.romaine.life` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)