### PR TITLE
fix(tofu): read AKS OIDC issuer from infra-bootstrap remote state

### DIFF
--- a/tofu/identity.tf
+++ b/tofu/identity.tf
@@ -13,16 +13,6 @@ data "azurerm_resource_group" "infra" {
   name = local.infra.resource_group_name
 }
 
-# Live cluster OIDC issuer URL. Previously pinned via var.cluster_oidc_issuer_url
-# default — that drifted silently when infra-bootstrap rebuilt the AKS cluster
-# and the federated cred kept presenting the old issuer (AADSTS700211). Reading
-# it from the cluster directly keeps the credential in lockstep with the
-# current cluster — matches diagrams/tofu/identity.tf.
-data "azurerm_kubernetes_cluster" "infra" {
-  name                = "infra-aks"
-  resource_group_name = local.infra.resource_group_name
-}
-
 resource "azurerm_user_assigned_identity" "investing" {
   name                = "investing-identity"
   resource_group_name = data.azurerm_resource_group.infra.name
@@ -52,7 +42,7 @@ resource "azurerm_federated_identity_credential" "investing" {
   resource_group_name = local.infra.resource_group_name
   parent_id           = azurerm_user_assigned_identity.investing.id
   audience            = ["api://AzureADTokenExchange"]
-  issuer              = data.azurerm_kubernetes_cluster.infra.oidc_issuer_url
+  issuer              = local.aks_oidc_issuer_url
   subject             = "system:serviceaccount:investing:infra-shared"
 }
 

--- a/tofu/remote-state.tf
+++ b/tofu/remote-state.tf
@@ -9,3 +9,25 @@ locals {
     key_vault_name               = "romaine-kv"
   }
 }
+
+# AKS cluster OIDC issuer URL comes from infra-bootstrap's state output.
+# Can't read it directly from `data "azurerm_kubernetes_cluster"` here:
+# the cluster lives in a dedicated subscription and our CI principal only
+# has access to the app subscription — the data source 404s. The tfstate
+# blob, on the other hand, is in this subscription's storage account and
+# is already in our principal's reach. Pattern matches glimmung/tofu/remote-state.tf.
+data "terraform_remote_state" "infra_bootstrap" {
+  backend = "azurerm"
+
+  config = {
+    resource_group_name  = "infra"
+    storage_account_name = "nelsontofu"
+    container_name       = "tfstate"
+    key                  = "infra-bootstrap.tfstate"
+    use_oidc             = true
+  }
+}
+
+locals {
+  aks_oidc_issuer_url = data.terraform_remote_state.infra_bootstrap.outputs.aks_oidc_issuer_url
+}


### PR DESCRIPTION
## Summary

Follow-up to #18 (which switched to a live `data.azurerm_kubernetes_cluster` source — that failed because the cluster lives in a different subscription than the CI principal can reach).

Read \`aks_oidc_issuer_url\` from infra-bootstrap's tfstate output instead. The tfstate blob is in the subscription our CI principal already has access to (it's where this stack's own state lives), so no cross-sub plumbing is needed. Matches the pattern in [glimmung/tofu/remote-state.tf](https://github.com/nelsong6/glimmung/blob/main/tofu/remote-state.tf) which has been working.

Apply will plan a single in-place update to \`azurerm_federated_identity_credential.investing.issuer\`, swapping the stale `…/dca02d36-…/` URL for the cluster's current `…/5aced6d5-…/`. The pod can then complete its workload-identity token exchange and stop crashlooping.

## Test plan
- [x] Tofu plan shows one in-place update on the federated cred
- [ ] After apply: `az identity federated-credential list --identity-name investing-identity` shows the new issuer URL
- [ ] After ArgoCD restart: `investing.romaine.life` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)