### PR TITLE
Quote image tag in values.yaml (YAML scientific-notation footgun)

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -51,7 +51,9 @@ jobs:
 
       - name: Bump image tag in k8s/values.yaml
         run: |
-          sed -i "s|^  tag: .*|  tag: ${{ env.TAG }}|" k8s/values.yaml
+          # Quote the tag: short SHAs like 4255e97 are valid YAML scientific
+          # notation and parse as a float (4.255e+100) unless quoted.
+          sed -i "s|^  tag: .*|  tag: \"${{ env.TAG }}\"|" k8s/values.yaml
 
       - name: Commit and push tag bump
         run: |

--- a/k8s/values.yaml
+++ b/k8s/values.yaml
@@ -2,4 +2,5 @@
 # push to main (via `sed` on this file).
 image:
   repository: romainecr.azurecr.io/investing
-  tag: b65b1b7
+  # Quoted on purpose: a bare SHA like 4255e97 is valid YAML scientific notation; keep the quotes.
+  tag: "b65b1b7"


### PR DESCRIPTION
A bare short SHA like 4255e97 is valid YAML scientific notation and parses
as a float (4.255e+100) when unquoted, yielding a broken image ref and an
InvalidImageName pod that silently wedges the rollout. Quote the tag in
values.yaml and make the deploy workflow's sed always emit a quoted tag.
Renders an identical image ref — no behavior change.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
