### PR TITLE
Use org pipeline templates

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   code-quality:
-    uses: nelsong6/pipeline-templates/.github/workflows/lint-template.yml@main
+    uses: romaine-life/pipeline-templates/.github/workflows/lint-template.yml@main
     with:
       working_directory: '.'
 

--- a/.github/workflows/tofu.yaml
+++ b/.github/workflows/tofu.yaml
@@ -24,7 +24,7 @@ permissions:
 
 jobs:
   tofu:
-    uses: nelsong6/pipeline-templates/.github/workflows/tofu-plan-apply-template.yml@main
+    uses: romaine-life/pipeline-templates/.github/workflows/tofu-plan-apply-template.yml@main
     with:
       working_directory: tofu
       backend_storage_account: ${{ vars.TFSTATE_STORAGE_ACCOUNT }}


### PR DESCRIPTION
Repoint reusable-workflow `uses:` references from `nelsong6/pipeline-templates` to `romaine-life/pipeline-templates` (org migration; the templates repo was transferred). Mechanical owner-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)